### PR TITLE
send broadcast message only when db connected state changes

### DIFF
--- a/server.js
+++ b/server.js
@@ -445,8 +445,12 @@ dbAbstraction.hello();
 async function dbPing() {
     try{
         let db = new DbAbstraction();
-        isDbConnected = await db.isdbAvailable();
-        io.emit('dbConnectivityState', {dbState: isDbConnected});
+        let currentDbState = await db.isdbAvailable();
+        if (isDbConnected !== currentDbState) {
+            console.log(`Db connected state has changed from ${isDbConnected} to ${currentDbState}`);
+            isDbConnected = currentDbState;
+            io.emit('dbConnectivityState', { dbState: isDbConnected });
+        }
         await db.destroy();
     }  catch (e) {
         console.log("Exception caught in db not available: ", e);


### PR DESCRIPTION
- Optimised broadcasting of db connected state to all the clients.
- Send only when db connections state changes.

- Tested through websocket network calls in UI.