### PR TITLE
feat: Add bulk upsert API endpoint (upsertBulkDocs)

### DIFF
--- a/dbAbstraction.js
+++ b/dbAbstraction.js
@@ -188,6 +188,108 @@ class DbAbstraction {
             throw err;
         }
     }
+
+    /**
+     * Bulk upsert documents — insert new docs or update existing ones based on selectorObj.
+     * @param {string} dbName - Database name
+     * @param {string} tableName - Collection name
+     * @param {Array<Object>} selectorObjs - Array of selector objects (matched by index with docs)
+     * @param {Array<Object>} docs - Array of documents to upsert
+     * @param {Object} options - Options object
+     * @param {boolean} options.insertOnly - If true, fails for existing docs; if false, updates them (default: false)
+     * @returns {Promise<{ok: number, inserted: Array, updated: Array, failures: Array}>}
+     */
+    async upsertMany(dbName, tableName, selectorObjs, docs, options = {}) {
+        const { insertOnly = false } = options;
+        try {
+            if (!this.isConnected) await this.connect();
+            let db = this.client.db(dbName);
+            let collection = db.collection(tableName);
+
+            // Validate arrays are same length
+            if (selectorObjs.length !== docs.length) {
+                return { ok: 0, error: 'selectorObjs and docs arrays must be same length' };
+            }
+
+            // Check for _id in selectors
+            for (let i = 0; i < selectorObjs.length; i++) {
+                if (selectorObjs[i]._id) {
+                    return { ok: 0, error: `selectorObjs[${i}] must not have _id` };
+                }
+            }
+
+            // Build bulkWrite operations
+            const bulkOps = selectorObjs.map((selector, index) => ({
+                updateOne: {
+                    filter: selector,
+                    update: insertOnly ? { $setOnInsert: docs[index] } : { $set: docs[index] },
+                    upsert: true
+                }
+            }));
+
+            // Execute bulk operation with ordered: false to continue on errors
+            const result = await collection.bulkWrite(bulkOps, { ordered: false });
+
+            // Build inserted, updated, and failures arrays
+            const inserted = [];
+            const updated = [];
+            const failures = [];
+
+            // Track which indices were upserted (new inserts)
+            const upsertedIndices = new Set();
+            if (result.upsertedIds) {
+                for (const [indexStr, id] of Object.entries(result.upsertedIds)) {
+                    const index = parseInt(indexStr);
+                    upsertedIndices.add(index);
+                    inserted.push({
+                        index,
+                        _id: id,
+                        selectorObj: selectorObjs[index]
+                    });
+                }
+            }
+
+            // Process documents that already existed (matched)
+            for (let i = 0; i < selectorObjs.length; i++) {
+                if (!upsertedIndices.has(i)) {
+                    // This doc already existed, find its _id
+                    const existingDoc = await collection.findOne(selectorObjs[i], { projection: { _id: 1 } });
+                    if (insertOnly) {
+                        // Insert-only mode: existing docs are failures
+                        failures.push({
+                            index: i,
+                            selectorObj: selectorObjs[i],
+                            error: 'Document with matching key already exists',
+                            existingId: existingDoc ? existingDoc._id : null
+                        });
+                    } else {
+                        // Upsert mode: existing docs were updated successfully
+                        updated.push({
+                            index: i,
+                            _id: existingDoc ? existingDoc._id : null,
+                            selectorObj: selectorObjs[i]
+                        });
+                    }
+                }
+            }
+
+            return {
+                ok: 1,
+                total: selectorObjs.length,
+                insertedCount: inserted.length,
+                updatedCount: updated.length,
+                failCount: failures.length,
+                inserted,
+                updated,
+                failures
+            };
+        } catch (err) {
+            logger.error(err, `upsertMany error for ${dbName}.${tableName}`);
+            this.handleDbErrors(err);
+            throw err;
+        }
+    }
+
     async update (dbName, tableName, selector, updateObj) {
         try {
             if (! this.isConnected ) await this.connect();

--- a/dbAbstraction.js
+++ b/dbAbstraction.js
@@ -212,11 +212,6 @@ class DbAbstraction {
      * @param {Object} options - Options object
      * @param {boolean} options.insertOnly - If true, fails for existing docs; if false, updates them (default: false)
      * @returns {Promise<{ok: number, inserted: Array, updated: Array, failures: Array}>}
-     *
-     * A selectorObj may contain an `_id` (string or ObjectId). When it does, that entry is
-     * treated as an update-by-identity (same as insertOrUpdateOneDoc): the `_id` is converted to
-     * an ObjectId, the row is updated in place, and if no such row exists it is reported as a
-     * `Row not found!` failure (never inserted). Selectors without `_id` keep upsert-by-key behavior.
      */
     async upsertMany(dbName, tableName, selectorObjs, docs, options = {}) {
         const { insertOnly = false } = options;
@@ -242,8 +237,6 @@ class DbAbstraction {
                 }
             }
 
-            // _id-based selectors update an existing row only (upsert: false, never insert a stray
-            // doc); natural-key selectors keep upsert-by-key behavior.
             const bulkOps = selectorObjs.map((selector, index) => ({
                 updateOne: {
                     filter: selector,
@@ -252,7 +245,6 @@ class DbAbstraction {
                 }
             }));
 
-            // ordered: ops run in array order and stop at the first failing op.
             const result = await collection.bulkWrite(bulkOps, { ordered: true });
 
             const inserted = [];
@@ -272,8 +264,6 @@ class DbAbstraction {
                 }
             }
 
-            // Resolve the _id of every doc that wasn't freshly inserted using one batched query
-            // instead of a findOne per row, then match results back to each selector in memory.
             const pendingIndices = [];
             for (let i = 0; i < selectorObjs.length; i++) {
                 if (!upsertedIndices.has(i)) pendingIndices.push(i);
@@ -295,24 +285,34 @@ class DbAbstraction {
                     const existingDoc = idBased[i]
                         ? byId.get(String(selectorObjs[i]._id))
                         : existingDocs.find(doc => this._docMatchesSelector(doc, selectorObjs[i]));
-                    if (idBased[i] && !existingDoc) {
-                        failures.push({
-                            index: i,
-                            selectorObj: selectorObjs[i],
-                            error: 'Row not found!'
-                        });
-                    } else if (insertOnly) {
-                        failures.push({
-                            index: i,
-                            selectorObj: selectorObjs[i],
-                            error: 'Document with matching key already exists',
-                            existingId: existingDoc ? existingDoc._id : null
-                        });
-                    } else {
+                    if (insertOnly) {
+                        if (existingDoc) {
+                            failures.push({
+                                index: i,
+                                selectorObj: selectorObjs[i],
+                                error: 'Document with matching key already exists',
+                                existingId: existingDoc._id
+                            });
+                        } else {
+                            // Neither matched nor upserted: the insert did not happen.
+                            failures.push({
+                                index: i,
+                                selectorObj: selectorObjs[i],
+                                error: idBased[i] ? 'Row not found!' : 'Insert did not happen'
+                            });
+                        }
+                    } else if (existingDoc) {
                         updated.push({
                             index: i,
-                            _id: existingDoc ? existingDoc._id : null,
+                            _id: existingDoc._id,
                             selectorObj: selectorObjs[i]
+                        });
+                    } else {
+                        // No row to update, and (for _id-based) no insert is allowed.
+                        failures.push({
+                            index: i,
+                            selectorObj: selectorObjs[i],
+                            error: idBased[i] ? 'Row not found!' : 'Update/insert did not happen'
                         });
                     }
                 }

--- a/dbAbstraction.js
+++ b/dbAbstraction.js
@@ -171,6 +171,20 @@ class DbAbstraction {
             throw err;
         }
     }
+    async insertMany (dbName, tableName, docs) {
+        try {
+            if (!docs || docs.length === 0) return { ok: 1, insertedCount: 0, insertedIds: {} };
+            if (! this.isConnected ) await this.connect();
+            let db = this.client.db(dbName);
+            let collection = db.collection(tableName);
+            let ret = await collection.insertMany(docs, { ordered: false });
+            return { ok: ret.acknowledged ? 1 : 0, insertedCount: ret.insertedCount, insertedIds: ret.insertedIds };
+        } catch (err) {
+            logger.error(err, `insertMany error for ${dbName}.${tableName}`);
+            this.handleDbErrors(err);
+            throw err;
+        }
+    }
     async insertOneUniquely (dbName, tableName, selector, setObj) {
         try {
             if (! this.isConnected ) await this.connect();
@@ -198,6 +212,11 @@ class DbAbstraction {
      * @param {Object} options - Options object
      * @param {boolean} options.insertOnly - If true, fails for existing docs; if false, updates them (default: false)
      * @returns {Promise<{ok: number, inserted: Array, updated: Array, failures: Array}>}
+     *
+     * A selectorObj may contain an `_id` (string or ObjectId). When it does, that entry is
+     * treated as an update-by-identity (same as insertOrUpdateOneDoc): the `_id` is converted to
+     * an ObjectId, the row is updated in place, and if no such row exists it is reported as a
+     * `Row not found!` failure (never inserted). Selectors without `_id` keep upsert-by-key behavior.
      */
     async upsertMany(dbName, tableName, selectorObjs, docs, options = {}) {
         const { insertOnly = false } = options;
@@ -206,36 +225,40 @@ class DbAbstraction {
             let db = this.client.db(dbName);
             let collection = db.collection(tableName);
 
-            // Validate arrays are same length
             if (selectorObjs.length !== docs.length) {
                 return { ok: 0, error: 'selectorObjs and docs arrays must be same length' };
             }
 
-            // Check for _id in selectors
+            // An `_id` marks an update-by-identity entry (convert it to ObjectId); drop `_id` from
+            // the doc payload so no row is ever inserted with a custom _id.
+            const idBased = new Array(selectorObjs.length).fill(false);
             for (let i = 0; i < selectorObjs.length; i++) {
                 if (selectorObjs[i]._id) {
-                    return { ok: 0, error: `selectorObjs[${i}] must not have _id` };
+                    selectorObjs[i]._id = this.getObjectId(selectorObjs[i]._id);
+                    idBased[i] = true;
+                }
+                if (docs[i] && docs[i]._id !== undefined) {
+                    delete docs[i]._id;
                 }
             }
 
-            // Build bulkWrite operations
+            // _id-based selectors update an existing row only (upsert: false, never insert a stray
+            // doc); natural-key selectors keep upsert-by-key behavior.
             const bulkOps = selectorObjs.map((selector, index) => ({
                 updateOne: {
                     filter: selector,
                     update: insertOnly ? { $setOnInsert: docs[index] } : { $set: docs[index] },
-                    upsert: true
+                    upsert: !idBased[index]
                 }
             }));
 
-            // Execute bulk operation with ordered: false to continue on errors
-            const result = await collection.bulkWrite(bulkOps, { ordered: false });
+            // ordered: ops run in array order and stop at the first failing op.
+            const result = await collection.bulkWrite(bulkOps, { ordered: true });
 
-            // Build inserted, updated, and failures arrays
             const inserted = [];
             const updated = [];
             const failures = [];
 
-            // Track which indices were upserted (new inserts)
             const upsertedIndices = new Set();
             if (result.upsertedIds) {
                 for (const [indexStr, id] of Object.entries(result.upsertedIds)) {
@@ -249,13 +272,36 @@ class DbAbstraction {
                 }
             }
 
-            // Process documents that already existed (matched)
+            // Resolve the _id of every doc that wasn't freshly inserted using one batched query
+            // instead of a findOne per row, then match results back to each selector in memory.
+            const pendingIndices = [];
             for (let i = 0; i < selectorObjs.length; i++) {
-                if (!upsertedIndices.has(i)) {
-                    // This doc already existed, find its _id
-                    const existingDoc = await collection.findOne(selectorObjs[i], { projection: { _id: 1 } });
-                    if (insertOnly) {
-                        // Insert-only mode: existing docs are failures
+                if (!upsertedIndices.has(i)) pendingIndices.push(i);
+            }
+
+            if (pendingIndices.length > 0) {
+                // Project the selector fields too so natural-key results can be matched back.
+                const projection = { _id: 1 };
+                for (const i of pendingIndices) {
+                    for (const key of Object.keys(selectorObjs[i])) projection[key] = 1;
+                }
+                const orConditions = pendingIndices.map(i => selectorObjs[i]);
+                const existingDocs = await collection.find({ $or: orConditions }, { projection }).toArray();
+
+                const byId = new Map();
+                for (const doc of existingDocs) byId.set(String(doc._id), doc);
+
+                for (const i of pendingIndices) {
+                    const existingDoc = idBased[i]
+                        ? byId.get(String(selectorObjs[i]._id))
+                        : existingDocs.find(doc => this._docMatchesSelector(doc, selectorObjs[i]));
+                    if (idBased[i] && !existingDoc) {
+                        failures.push({
+                            index: i,
+                            selectorObj: selectorObjs[i],
+                            error: 'Row not found!'
+                        });
+                    } else if (insertOnly) {
                         failures.push({
                             index: i,
                             selectorObj: selectorObjs[i],
@@ -263,7 +309,6 @@ class DbAbstraction {
                             existingId: existingDoc ? existingDoc._id : null
                         });
                     } else {
-                        // Upsert mode: existing docs were updated successfully
                         updated.push({
                             index: i,
                             _id: existingDoc ? existingDoc._id : null,
@@ -288,6 +333,26 @@ class DbAbstraction {
             this.handleDbErrors(err);
             throw err;
         }
+    }
+
+    /**
+     * Returns true if `doc` satisfies every field-equality in `selector`.
+     * Handles ObjectId (and other BSON types exposing `.equals`) and falls back to a
+     * structural compare for nested objects/arrays. Assumes equality-style selectors.
+     */
+    _docMatchesSelector(doc, selector) {
+        for (const key of Object.keys(selector)) {
+            const sv = selector[key];
+            const dv = doc[key];
+            if (sv && typeof sv === 'object' && typeof sv.equals === 'function') {
+                if (!(dv && typeof dv.equals === 'function' && sv.equals(dv))) return false;
+            } else if (sv !== null && typeof sv === 'object') {
+                if (JSON.stringify(sv) !== JSON.stringify(dv)) return false;
+            } else if (dv !== sv) {
+                return false;
+            }
+        }
+        return true;
     }
 
     async update (dbName, tableName, selector, updateObj) {

--- a/perRowAccessCheck.js
+++ b/perRowAccessCheck.js
@@ -14,6 +14,29 @@ async function checkAccessForSpecificRow(dsName, dsView, dsUser, _id) {
     return recs;
 }
 
+// Batched checkAccessForSpecificRow: returns a Set of the id strings the user may access.
+// Malformed _ids are skipped (treated as not accessible).
+async function checkAccessForSpecificRows(dsName, dsView, dsUser, ids) {
+    let dbAbstraction = new DbAbstraction();
+    let allowed = new Set();
+    let objectIds = [];
+    for (const id of ids) {
+        try {
+            objectIds.push(dbAbstraction.getObjectId(id));
+        } catch (e) {
+            logger.error(e, `checkAccessForSpecificRows: invalid _id ${id}`);
+        }
+    }
+    if (objectIds.length === 0) return allowed;
+    // Enforcing on an empty filter set yields just the access-column constraint (or nothing).
+    let [accessQFilters] = await enforcePerRowAcessCtrl(dsName, dsView, dsUser, []);
+    let [accessFilters] = MongoFilters.getMongoFiltersAndSorters(accessQFilters, null, null);
+    let query = { ...accessFilters, _id: { $in: objectIds } };
+    let recs = await dbAbstraction.find(dsName, "data", query, { projection: { _id: 1 } });
+    for (const rec of recs) allowed.add(String(rec._id));
+    return allowed;
+}
+
 async function enforcePerRowAcessCtrl(dsName, dsView, dsUser, filters, collection = "data") {
     let dbAbstraction = new DbAbstraction();
     let onlyPerRowAccessCtrlQueried = false;
@@ -125,6 +148,7 @@ async function checkIfUserCanCopyDs (dsName, dsUser) {
 
 module.exports = {
     checkAccessForSpecificRow,
+    checkAccessForSpecificRows,
     enforcePerRowAcessCtrl,
     checkIfUserCanEditPerRowAccessConfig,
     checkIfUserCanCopyDs

--- a/routes/dsReadApi.js
+++ b/routes/dsReadApi.js
@@ -1121,6 +1121,170 @@ router.post('/view/insertOneDoc', async (req, res, next) => {
 
 /**
  * @swagger
+ * /ds/view/upsertBulkDocs:
+ *   post:
+ *     summary: Bulk upsert documents — insert new docs or update existing ones based on selectorObj
+ *     tags: [Datasets]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [dsName, dsView, dsUser, selectorObjs, docs]
+ *             properties:
+ *               dsName: { type: string, description: Dataset name }
+ *               dsView: { type: string, default: default, description: View name }
+ *               dsUser: { type: string, description: Username }
+ *               selectorObjs:
+ *                 type: array
+ *                 items: { type: object }
+ *                 description: Array of key selector objects (matched by index with docs)
+ *               docs:
+ *                 type: array
+ *                 items: { type: object }
+ *                 description: Array of documents to upsert (matched by index with selectorObjs)
+ *               insertOnly:
+ *                 type: boolean
+ *                 default: false
+ *                 description: If true, fails for existing docs; if false, updates them
+ *     responses:
+ *       200:
+ *         description: Bulk upsert result with inserted, updated, and failures
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status: { type: string, enum: [success, partial, fail] }
+ *                 total: { type: number }
+ *                 insertedCount: { type: number }
+ *                 updatedCount: { type: number }
+ *                 failCount: { type: number }
+ *                 inserted:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       _id: { type: string }
+ *                       selectorObj: { type: object }
+ *                 updated:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       _id: { type: string }
+ *                       selectorObj: { type: object }
+ *                 failures:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       selectorObj: { type: object }
+ *                       error: { type: string }
+ *                       existingId: { type: string }
+ *       400:
+ *         description: Validation error
+ *       403:
+ *         description: Access denied
+ */
+router.post('/view/upsertBulkDocs', async (req, res, next) => {
+    let request = req.body;
+    logger.info("Incoming request in upsertBulkDocs");
+    
+    // Validate required fields
+    if (!request.dsName || !request.dsView || !request.dsUser) {
+        res.status(400).json({ status: 'fail', error: 'Missing required fields: dsName, dsView, dsUser' });
+        return;
+    }
+    if (!Array.isArray(request.selectorObjs) || !Array.isArray(request.docs)) {
+        res.status(400).json({ status: 'fail', error: 'selectorObjs and docs must be arrays' });
+        return;
+    }
+    if (request.selectorObjs.length !== request.docs.length) {
+        res.status(400).json({ status: 'fail', error: 'selectorObjs and docs arrays must be same length' });
+        return;
+    }
+    if (request.selectorObjs.length === 0) {
+        res.status(400).json({ status: 'fail', error: 'selectorObjs and docs arrays cannot be empty' });
+        return;
+    }
+
+    const token = req.cookies.jwt;
+    let allowed = await AclCheck.aclCheck(request.dsName, request.dsView, request.dsUser, token);
+    if (!allowed) {
+        res.status(403).json({ "Error": "access_denied" });
+        return;
+    }
+
+    let dbAbstraction = new DbAbstraction();
+    try {
+        const insertOnly = request.insertOnly === true;
+        let dbResponse = await dbAbstraction.upsertMany(request.dsName, "data", request.selectorObjs, request.docs, { insertOnly });
+        logger.info(dbResponse, 'DB response after upsertMany');
+
+        if (dbResponse.ok !== 1) {
+            res.status(400).json({ status: 'fail', error: dbResponse.error || 'Bulk upsert failed' });
+            return;
+        }
+
+        // Determine overall status
+        let status;
+        const successCount = dbResponse.insertedCount + dbResponse.updatedCount;
+        if (dbResponse.failCount === 0) {
+            status = 'success';
+        } else if (successCount === 0) {
+            status = 'fail';
+        } else {
+            status = 'partial';
+        }
+
+        // Create editlog entries for inserted docs
+        for (const item of dbResponse.inserted) {
+            let editLogEntry = {
+                opr: "insert",
+                selector: JSON.stringify(item.selectorObj, null, 4),
+                doc: JSON.stringify(request.docs[item.index], null, 4),
+                user: request.dsUser,
+                date: Date(),
+                status: 'success'
+            };
+            await dbAbstraction.insertOne(request.dsName, "editlog", editLogEntry);
+        }
+
+        // Create editlog entries for updated docs
+        for (const item of dbResponse.updated) {
+            let editLogEntry = {
+                opr: "update",
+                selector: JSON.stringify(item.selectorObj, null, 4),
+                doc: JSON.stringify(request.docs[item.index], null, 4),
+                user: request.dsUser,
+                date: Date(),
+                status: 'success'
+            };
+            await dbAbstraction.insertOne(request.dsName, "editlog", editLogEntry);
+        }
+
+        let response = {
+            status,
+            total: dbResponse.total,
+            insertedCount: dbResponse.insertedCount,
+            updatedCount: dbResponse.updatedCount,
+            failCount: dbResponse.failCount,
+            inserted: dbResponse.inserted.map(s => ({ _id: s._id, selectorObj: s.selectorObj })),
+            updated: dbResponse.updated.map(s => ({ _id: s._id, selectorObj: s.selectorObj })),
+            failures: dbResponse.failures.map(f => ({ selectorObj: f.selectorObj, error: f.error, existingId: f.existingId }))
+        };
+
+        res.status(200).send(response);
+    } catch (e) {
+        logger.error(e, "Exception in upsertBulkDocs");
+        res.status(415).send({ status: 'fail', error: e.message || 'Server error' });
+    }
+});
+
+/**
+ * @swagger
  * /ds/view/insertOrUpdateOneDoc:
  *   post:
  *     summary: Upsert a document — insert if not exists, update if exists

--- a/routes/dsReadApi.js
+++ b/routes/dsReadApi.js
@@ -1220,7 +1220,42 @@ router.post('/view/upsertBulkDocs', async (req, res, next) => {
     let dbAbstraction = new DbAbstraction();
     try {
         const insertOnly = request.insertOnly === true;
-        let dbResponse = await dbAbstraction.upsertMany(request.dsName, "data", request.selectorObjs, request.docs, { insertOnly });
+
+        // Per-row access enforcement (mirrors insertOrUpdateOneDoc): _id-based selectors the user
+        // can't access are dropped and reported as 'Row not found!'. Natural-key selectors (no _id)
+        // pass through unchanged, since the single-doc path only checks access when _id is present.
+        let idStrings = [];
+        for (const sel of request.selectorObjs) {
+            if (sel && sel._id) idStrings.push(String(sel._id));
+        }
+        let allowedIdSet = idStrings.length > 0
+            ? await PerRowAcessCheck.checkAccessForSpecificRows(request.dsName, request.dsView, request.dsUser, idStrings)
+            : new Set();
+
+        let allowedSelectorObjs = [];
+        let allowedDocs = [];
+        let accessFailures = [];
+        for (let i = 0; i < request.selectorObjs.length; i++) {
+            let sel = request.selectorObjs[i];
+            if (sel && sel._id) {
+                if (allowedIdSet.has(String(sel._id))) {
+                    allowedSelectorObjs.push(sel);
+                    allowedDocs.push(request.docs[i]);
+                } else {
+                    accessFailures.push({ selectorObj: sel, error: 'Row not found!' });
+                }
+            } else {
+                allowedSelectorObjs.push(sel);
+                allowedDocs.push(request.docs[i]);
+            }
+        }
+
+        let dbResponse;
+        if (allowedSelectorObjs.length > 0) {
+            dbResponse = await dbAbstraction.upsertMany(request.dsName, "data", allowedSelectorObjs, allowedDocs, { insertOnly });
+        } else {
+            dbResponse = { ok: 1, insertedCount: 0, updatedCount: 0, failCount: 0, inserted: [], updated: [], failures: [] };
+        }
         logger.info(dbResponse, 'DB response after upsertMany');
 
         if (dbResponse.ok !== 1) {
@@ -1228,10 +1263,12 @@ router.post('/view/upsertBulkDocs', async (req, res, next) => {
             return;
         }
 
-        // Determine overall status
+        let failures = [...dbResponse.failures, ...accessFailures];
+        let failCount = dbResponse.failCount + accessFailures.length;
+
         let status;
         const successCount = dbResponse.insertedCount + dbResponse.updatedCount;
-        if (dbResponse.failCount === 0) {
+        if (failCount === 0) {
             status = 'success';
         } else if (successCount === 0) {
             status = 'fail';
@@ -1239,41 +1276,41 @@ router.post('/view/upsertBulkDocs', async (req, res, next) => {
             status = 'partial';
         }
 
-        // Create editlog entries for inserted docs
+        // item.index refers to allowedDocs (the filtered arrays actually sent to upsertMany).
+        let editLogEntries = [];
         for (const item of dbResponse.inserted) {
-            let editLogEntry = {
+            editLogEntries.push({
                 opr: "insert",
                 selector: JSON.stringify(item.selectorObj, null, 4),
-                doc: JSON.stringify(request.docs[item.index], null, 4),
+                doc: JSON.stringify(allowedDocs[item.index], null, 4),
                 user: request.dsUser,
                 date: Date(),
                 status: 'success'
-            };
-            await dbAbstraction.insertOne(request.dsName, "editlog", editLogEntry);
+            });
         }
-
-        // Create editlog entries for updated docs
         for (const item of dbResponse.updated) {
-            let editLogEntry = {
+            editLogEntries.push({
                 opr: "update",
                 selector: JSON.stringify(item.selectorObj, null, 4),
-                doc: JSON.stringify(request.docs[item.index], null, 4),
+                doc: JSON.stringify(allowedDocs[item.index], null, 4),
                 user: request.dsUser,
                 date: Date(),
                 status: 'success'
-            };
-            await dbAbstraction.insertOne(request.dsName, "editlog", editLogEntry);
+            });
+        }
+        if (editLogEntries.length > 0) {
+            await dbAbstraction.insertMany(request.dsName, "editlog", editLogEntries);
         }
 
         let response = {
             status,
-            total: dbResponse.total,
+            total: request.selectorObjs.length,
             insertedCount: dbResponse.insertedCount,
             updatedCount: dbResponse.updatedCount,
-            failCount: dbResponse.failCount,
+            failCount: failCount,
             inserted: dbResponse.inserted.map(s => ({ _id: s._id, selectorObj: s.selectorObj })),
             updated: dbResponse.updated.map(s => ({ _id: s._id, selectorObj: s.selectorObj })),
-            failures: dbResponse.failures.map(f => ({ selectorObj: f.selectorObj, error: f.error, existingId: f.existingId }))
+            failures: failures.map(f => ({ selectorObj: f.selectorObj, error: f.error, existingId: f.existingId }))
         };
 
         res.status(200).send(response);

--- a/routes/dsReadApi.js
+++ b/routes/dsReadApi.js
@@ -874,6 +874,17 @@ function getInsertLog (req, status) {
     return insertDoc;
 }
 
+function getUpdateLog (req, status) {
+    let updateDoc = {};
+    updateDoc.opr = "update";
+    updateDoc.selector = JSON.stringify(req.selectorObj, null, 4);
+    updateDoc.doc = JSON.stringify(req.doc, null, 4);
+    updateDoc.user = req.dsUser;
+    updateDoc.date = Date();
+    updateDoc.status = status;
+    return updateDoc;
+}
+
 function getDeleteLog (req, _doc, status) {
     let selectorObj = JSON.parse(JSON.stringify(req.selectorObj));
     logger.info(_doc, `In getDeleteLog`);
@@ -1205,7 +1216,7 @@ router.post('/view/upsertBulkDocs', async (req, res, next) => {
         res.status(400).json({ status: 'fail', error: 'selectorObjs and docs arrays must be same length' });
         return;
     }
-    if (request.selectorObjs.length === 0) {
+    if (request.selectorObjs.length === 0 || request.docs.length === 0) {
         res.status(400).json({ status: 'fail', error: 'selectorObjs and docs arrays cannot be empty' });
         return;
     }
@@ -1221,9 +1232,6 @@ router.post('/view/upsertBulkDocs', async (req, res, next) => {
     try {
         const insertOnly = request.insertOnly === true;
 
-        // Per-row access enforcement (mirrors insertOrUpdateOneDoc): _id-based selectors the user
-        // can't access are dropped and reported as 'Row not found!'. Natural-key selectors (no _id)
-        // pass through unchanged, since the single-doc path only checks access when _id is present.
         let idStrings = [];
         for (const sel of request.selectorObjs) {
             if (sel && sel._id) idStrings.push(String(sel._id));
@@ -1279,24 +1287,10 @@ router.post('/view/upsertBulkDocs', async (req, res, next) => {
         // item.index refers to allowedDocs (the filtered arrays actually sent to upsertMany).
         let editLogEntries = [];
         for (const item of dbResponse.inserted) {
-            editLogEntries.push({
-                opr: "insert",
-                selector: JSON.stringify(item.selectorObj, null, 4),
-                doc: JSON.stringify(allowedDocs[item.index], null, 4),
-                user: request.dsUser,
-                date: Date(),
-                status: 'success'
-            });
+            editLogEntries.push(getInsertLog({ selectorObj: item.selectorObj, doc: allowedDocs[item.index], dsUser: request.dsUser }, 'success'));
         }
         for (const item of dbResponse.updated) {
-            editLogEntries.push({
-                opr: "update",
-                selector: JSON.stringify(item.selectorObj, null, 4),
-                doc: JSON.stringify(allowedDocs[item.index], null, 4),
-                user: request.dsUser,
-                date: Date(),
-                status: 'success'
-            });
+            editLogEntries.push(getUpdateLog({ selectorObj: item.selectorObj, doc: allowedDocs[item.index], dsUser: request.dsUser }, 'success'));
         }
         if (editLogEntries.length > 0) {
             await dbAbstraction.insertMany(request.dsName, "editlog", editLogEntries);


### PR DESCRIPTION
- Add upsertMany() method to dbAbstraction.js for bulk insert/update operations
- Add POST /ds/view/upsertBulkDocs endpoint to dsReadApi.js
- Supports both insert-only mode (insertOnly: true) and upsert mode (default)
- Returns detailed response with inserted, updated, and failed documents